### PR TITLE
CCQueue Worker  - Supports Laravel 5.2 and php 5.6

### DIFF
--- a/src/Console/Commands/CCQueueWorkerCommand.php
+++ b/src/Console/Commands/CCQueueWorkerCommand.php
@@ -33,7 +33,7 @@ class CCQueueWorkerCommand extends Command
 
     public function handle()
     {
-        Log::info('CCQueueWorkerCommand started(LEGACY)');
+        Log::info('CCQueueWorkerCommand started');
 
         $version = $this->argument('version');
 

--- a/src/Console/Commands/CCQueueWorkerCommand.php
+++ b/src/Console/Commands/CCQueueWorkerCommand.php
@@ -62,7 +62,7 @@ class CCQueueWorkerCommand extends Command
 
         while (true) {
 
-            queueItem = null;
+            $queueItem = null;
 
             // Weighted Fair Scheduling: Up to 5 high, then 1 normal, then 1 low, then repeat.
             if ($highCount < $highLimit) {

--- a/src/Console/Commands/CCQueueWorkerCommand.php
+++ b/src/Console/Commands/CCQueueWorkerCommand.php
@@ -57,7 +57,44 @@ class CCQueueWorkerCommand extends Command
         // Make sure logs are flushed before starting the worker
         $this->flushLogs();
 
+        $highCount = 0;
+        $highLimit = 5; // Number of high-priority jobs before checking normal/low
+
         while (true) {
+
+            queueItem = null;
+
+            // Weighted Fair Scheduling: Up to 5 high, then 1 normal, then 1 low, then repeat.
+            if ($highCount < $highLimit) {
+                // Try high-priority queue first
+                $queueItem = $redis->brpop([$queueHigh], 1);
+                if ($queueItem) {
+                    $highCount++;
+                }
+            }
+
+            // If no high-priority job this round, try normal
+            if (!$queueItem) {
+                $queueItem = $redis->brpop([$queueNormal], 1);
+                if ($queueItem) {
+                    $highCount = 0; // Reset high-priority counter
+                }
+            }
+
+            // If still nothing, try low
+            if (!$queueItem) {
+                $queueItem = $redis->brpop([$queueLow], 1);
+                if ($queueItem) {
+                    $highCount = 0; // Reset high-priority counter
+                }
+            }
+
+            // If nothing was found in any queue, sleep briefly and retry
+            if (!$queueItem) {
+                usleep(500000); // 0.5 second sleep if no job
+                continue;
+            }
+            
             $queueItem = $redis->brpop([$queueHigh, $queueNormal, $queueLow], 5);
 
             try {

--- a/src/Console/Commands/CCQueueWorkerCommand.php
+++ b/src/Console/Commands/CCQueueWorkerCommand.php
@@ -5,16 +5,53 @@ namespace CCQueue\Console\Commands;
 use Carbon\Carbon;
 use CCQueue\Services\JobDispatcher;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
 
 class CCQueueWorkerCommand extends Command
 {
-    protected $signature = 'cc-queue:worker {--version=default}';
+    protected $signature = 'cc-queue:worker {version=default}';
     protected $description = 'Process jobs from the CC Queue with priority and retry limit support';
+
+    /**
+     * Job handlers mapping
+     * @var array
+     */
+    protected $jobHandlers = [];
+    protected $retryLimit;
+    protected $useBusDispatch = true;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->jobHandlers = config('cc-queue.handlers', []);
+        $this->retryLimit = config('cc-queue.retry_limit', 3);
+    } 
 
     public function handle()
     {
+        Log::info('CCQueueWorkerCommand started(LEGACY)');
+
         $version = $this->argument('version');
+
+
+        $this->info(json_encode([
+            'env' => getenv('APP_ENV'),
+            'log' => getenv('APP_LOG'),
+            'log_level' => getenv('APP_LOG_LEVEL'),
+            // 'user' => get_current_user(),
+            'cwd' => getcwd(),
+            'php' => phpversion(),
+        ], JSON_PRETTY_PRINT));
+
+        /**
+         * If the version is default, we use Bus::dispatchNow() - Laravel 6+
+         * If the version is legacy, we use direct handle() - Laravel 5.2
+         */
+        $this->useBusDispatch = strtolower($this->argument('version')) !== 'legacy';
         $redis = Redis::connection();
 
         // Define Redis keys for different priority queues.
@@ -27,10 +64,14 @@ class CCQueueWorkerCommand extends Command
 
         $this->info("Worker started on queues: [$queueHigh, $queueNormal, $queueLow]");
 
+        // Make sure logs are flushed before starting the worker
+        $this->flushLogs();
+
         while (true) {
-            $job = $redis->brpop([$queueHigh, $queueNormal, $queueLow], 5);
+            $queueItem = $redis->brpop([$queueHigh, $queueNormal, $queueLow], 5);
 
             try {
+                $job = $queueItem[1]; // This is related to brpop array index.
                 if (!$job) {
                     usleep(500000); // 0.5 second sleep if no job
                     continue;
@@ -53,6 +94,7 @@ class CCQueueWorkerCommand extends Command
                     continue;
                 }
 
+                $this->info('Updating job status to in progress: ' . $jobUuid);
                 $dispatcher->updateJobStatus(
                     $jobUuid,
                     JobDispatcher::STATUS_IN_PROGRESS,
@@ -62,6 +104,7 @@ class CCQueueWorkerCommand extends Command
                 $this->processJob($payload);
 
                 // If processing succeeds, mark the job as "completed".
+                $this->info('Marking job as completed: ' . $jobUuid);
                 $dispatcher->updateJobStatus(
                     $jobUuid,
                     JobDispatcher::STATUS_COMPLETED,
@@ -85,6 +128,8 @@ class CCQueueWorkerCommand extends Command
                     }
                 }
             }
+
+            $this->flushLogs();
         }
     }
 
@@ -115,22 +160,53 @@ class CCQueueWorkerCommand extends Command
      */
     protected function processJob(array $payload)
     {
-        $jobUuid = $payload['uuid'] ?? null;
+        $jobUuid = $payload['uuid'] ? $payload['uuid'] : null;
         if (!$jobUuid) {
             throw new \Exception("Job UUID not found in payload.");
         }
 
-        $type = $payload['type'] ?? null;
-        $action = $payload['action'] ?? 'default';
-        $version = $payload['version'] ?? 'default';
+        $type = isset($payload['type']) ? $payload['type'] : null;
+        $action = isset($payload['action']) ? $payload['action'] : 'default';
+        $version = isset($payload['version']) ? $payload['version'] : $this->argument('version');
+
+        $this->info('Processing job: ' . $jobUuid);
 
         if (isset($this->jobHandlers[$type][$action])) {
             $jobClass = $this->jobHandlers[$type][$action];
             $jobInstance = new $jobClass($payload['data'], $version, $jobUuid);
+            $this->info('Executing job: ' . $jobUuid);
             // Dispatch the job immediately.
-            Bus::dispatchNow($jobInstance);
+            if ($this->useBusDispatch) {
+                Bus::dispatchNow($jobInstance);
+            } else {
+                $jobInstance->handle();
+            }
         } else {
             throw new \Exception("Unknown job type or action: {$type} / {$action}");
+        }
+    }
+
+    /**
+     * Force flush logs to disk immediately
+     */
+    private function flushLogs()
+    {
+        try {
+            // Flush Laravel's log
+            if (app()->bound('log')) {
+                $logger = app('log');
+                if (method_exists($logger, 'getMonolog')) {
+                    $monolog = $logger->getMonolog();
+                    if (method_exists($monolog, 'close')) {
+                        $monolog->close();
+                    }
+                }
+            }
+
+            // Also flush PHP's error log buffer
+            error_log('', 4);
+        } catch (\Exception $e) {
+            // Silently handle any flushing errors
         }
     }
 }

--- a/src/Console/Commands/CCQueueWorkerCommand.php
+++ b/src/Console/Commands/CCQueueWorkerCommand.php
@@ -61,7 +61,6 @@ class CCQueueWorkerCommand extends Command
         $highLimit = 5; // Number of high-priority jobs before checking normal/low
 
         while (true) {
-
             $queueItem = null;
 
             // Weighted Fair Scheduling: Up to 5 high, then 1 normal, then 1 low, then repeat.
@@ -95,8 +94,6 @@ class CCQueueWorkerCommand extends Command
                 continue;
             }
             
-            $queueItem = $redis->brpop([$queueHigh, $queueNormal, $queueLow], 5);
-
             try {
                 $job = $queueItem[1]; // This is related to brpop array index.
                 if (!$job) {

--- a/src/Console/Commands/CCQueueWorkerCommand.php
+++ b/src/Console/Commands/CCQueueWorkerCommand.php
@@ -37,16 +37,6 @@ class CCQueueWorkerCommand extends Command
 
         $version = $this->argument('version');
 
-
-        $this->info(json_encode([
-            'env' => getenv('APP_ENV'),
-            'log' => getenv('APP_LOG'),
-            'log_level' => getenv('APP_LOG_LEVEL'),
-            // 'user' => get_current_user(),
-            'cwd' => getcwd(),
-            'php' => phpversion(),
-        ], JSON_PRETTY_PRINT));
-
         /**
          * If the version is default, we use Bus::dispatchNow() - Laravel 6+
          * If the version is legacy, we use direct handle() - Laravel 5.2

--- a/src/Jobs/BaseJob.php
+++ b/src/Jobs/BaseJob.php
@@ -28,11 +28,11 @@ abstract class BaseJob implements ShouldQueue
         ];
     }
 
-    public static function fromArray(array $payload)
+    public static function fromArray(array $payload, $version = null)
     {
         $instance = new static(
             !empty($payload['data']) ? $payload['data'] : [],
-            !empty($payload['version']) ? $payload['version'] : 'default', // Provide default value for version,
+            !empty($payload['version']) ? $payload['version'] : $version, // Provide default value for version,
             !empty($payload['uuid']) ? $payload['uuid'] : null
         );
 

--- a/src/Providers/CCQueueServiceProvider.php
+++ b/src/Providers/CCQueueServiceProvider.php
@@ -47,10 +47,13 @@ class CCQueueServiceProvider extends ServiceProvider
 
         $this->setupConfig($this->app);
         $this->setupMigrations($this->app);
+        $this->setupCommands($this->app);
 
         // Register the commands
         if ($this->app->runningInConsole()) {
-            $this->commands([]);
+            $this->commands([
+                \CCQueue\Console\Commands\CCQueueWorkerCommand::class,
+            ]);
         }
     }
 
@@ -92,7 +95,7 @@ class CCQueueServiceProvider extends ServiceProvider
     {
         if ($app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'../Console/Commands/CCQueueWorkerCommand.php' => app_path('Console/Commands/CCQueueWorkerCommand.php'),
+                __DIR__.'/../Console/Commands/CCQueueWorkerCommand.php' => app_path('Console/Commands/CCQueueWorkerCommand.php'),
             ], 'commands');
         }
     }

--- a/src/Providers/CCQueueServiceProvider.php
+++ b/src/Providers/CCQueueServiceProvider.php
@@ -94,9 +94,9 @@ class CCQueueServiceProvider extends ServiceProvider
     protected function setupCommands($app)
     {
         if ($app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../Console/Commands/CCQueueWorkerCommand.php' => app_path('Console/Commands/CCQueueWorkerCommand.php'),
-            ], 'commands');
+            // $this->publishes([
+            //     __DIR__.'/../Console/Commands/CCQueueWorkerCommand.php' => app_path('Console/Commands/CCQueueWorkerCommand.php'),
+            // ], 'commands');
         }
     }
 

--- a/src/Providers/CCQueueServiceProvider.php
+++ b/src/Providers/CCQueueServiceProvider.php
@@ -94,6 +94,7 @@ class CCQueueServiceProvider extends ServiceProvider
     protected function setupCommands($app)
     {
         if ($app->runningInConsole()) {
+            // Comment out the publish command to avoid conflicts with the app's own commands
             // $this->publishes([
             //     __DIR__.'/../Console/Commands/CCQueueWorkerCommand.php' => app_path('Console/Commands/CCQueueWorkerCommand.php'),
             // ], 'commands');

--- a/src/Services/JobDispatcher.php
+++ b/src/Services/JobDispatcher.php
@@ -53,7 +53,7 @@ class JobDispatcher
         Redis::hmset($jobKey, $job);
         // Help prevent memory leaks by expiring the job after a certain amount of time.
         if ($expireLength > 0) {
-            Redis::expire($key, $expireLength);
+            Redis::expire($jobKey, $expireLength);
         }
         Redis::lpush($this->getQueueKey($version, $priority), json_encode($payload));
 


### PR DESCRIPTION
Added support for Laravel 5.2 and php 5.6 by moving 8.2 specific code, and grab context by version.
Support job queue with laravel 10 and just executing jobs in laravel 5.2
Update the console scripts when installing
Prevent starvation (balance all the queues so one doesn't completely shut out the others).

Requires: https://github.com/cloudcompli-enterprise/docker/pull/80